### PR TITLE
cifsd-tools: call setsid() in no-detach mode

### DIFF
--- a/cifsd/cifsd.c
+++ b/cifsd/cifsd.c
@@ -332,8 +332,6 @@ static pid_t start_worker_process(worker_fn fn)
 
 static int manager_process_init(void)
 {
-	int ret;
-
 	setup_signals(manager_sig_handler);
 	if (no_detach == 0) {
 		pr_logger_init(PR_LOGGER_SYSLOG);
@@ -341,6 +339,13 @@ static int manager_process_init(void)
 			pr_err("Daemonization failed\n");
 			goto out;
 		}
+	} else {
+		/*
+		 * Make ourselves a process group leader; if we are
+		 * the group leader already then the function will do
+		 * nothing (apart from setting errnor to EPERM).
+		 */
+		setsid();
 	}
 
 	if (create_lock_file()) {
@@ -380,7 +385,7 @@ static int manager_process_init(void)
 out:
 	delete_lock_file();
 	kill(0, SIGTERM);
-	return ret;
+	return 0;
 }
 
 static int manager_systemd_service(void)


### PR DESCRIPTION
If manager process is not a process group leader (which can
happen in no-detach mode) then make ourselves one.

Signed-off-by: Haythem Zidi <zidihaythem@gmail.com>
Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>