### PR TITLE
cifsd-tools: password hash size should be 16

### DIFF
--- a/lib/management/user.c
+++ b/lib/management/user.c
@@ -292,7 +292,7 @@ static void __handle_login_request(struct cifsd_login_response *resp,
 	hash_sz = usm_copy_user_passhash(user,
 					 resp->hash,
 					 sizeof(resp->hash));
-	if (hash_sz < 0) {
+	if (hash_sz != CIFSD_REQ_MAX_HASH_SZ - 2) {
 		resp->status = CIFSD_USER_FLAG_INVALID;
 	} else {
 		resp->hash_sz = (unsigned short)hash_sz;


### PR DESCRIPTION
If cifsdpwd.db is corrupted or old one is used, password hash size could
be smaller than CIFSD_REQ_MAX_HASH_SZ - 2(16). It cause null pointer dereferencing
issue.
See : memcpy(p21, user_passkey(sess->user), CIFS_NTHASH_SIZE); in auth.c

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>