### PR TITLE
cifsd-tools: always parse req_hdr for DCERPC_PTYPE_RPC_REQUEST

### DIFF
--- a/cifsd/rpc.c
+++ b/cifsd/rpc.c
@@ -1065,11 +1065,11 @@ int rpc_write_request(struct cifsd_rpc_command *req,
 	if (dce->hdr.ptype != DCERPC_PTYPE_RPC_REQUEST)
 		return CIFSD_RPC_ENOTIMPLEMENTED;
 
-	if (req->flags & CIFSD_RPC_SRVSVC_METHOD_INVOKE) {
-		if (dcerpc_request_hdr_read(dce, &dce->req_hdr))
-			return CIFSD_RPC_EBAD_DATA;
+	if (dcerpc_request_hdr_read(dce, &dce->req_hdr))
+		return CIFSD_RPC_EBAD_DATA;
+
+	if (req->flags & CIFSD_RPC_SRVSVC_METHOD_INVOKE)
 		return rpc_srvsvc_write_request(pipe);
-	}
 
 	if (req->flags & CIFSD_RPC_WKSSVC_METHOD_INVOKE)
 		return rpc_wkssvc_write_request(pipe);

--- a/cifsd/rpc_wkssvc.c
+++ b/cifsd/rpc_wkssvc.c
@@ -144,8 +144,6 @@ static int
 wkssvc_parse_netwksta_info_req(struct cifsd_dcerpc *dce,
 			       struct wkssvc_netwksta_info_request *hdr)
 {
-	if (ndr_read_union_int32(dce) == -EINVAL)
-		return -EINVAL;
 	ndr_read_uniq_vsting_ptr(dce, &hdr->server_name);
 	hdr->level = ndr_read_int32(dce);
 	return 0;


### PR DESCRIPTION
Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>