### PR TITLE
cifsd-tools: fix for a problem which does not exist

### DIFF
--- a/cifsd/ipc.c
+++ b/cifsd/ipc.c
@@ -201,8 +201,10 @@ int ipc_process_event(void)
 	int ret = 0;
 
 	ret = nl_recvmsgs_default(sk);
-	if (ret < 0)
+	if (ret < 0) {
 		pr_err("Recv() error %s [%d]\n", nl_geterror(ret), ret);
+		return -CIFSD_STATUS_IPC_FATAL_ERROR;
+	}
 	return ret;
 }
 

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -23,6 +23,8 @@ struct cifsd_ipc_msg {
 #define CIFSD_IPC_MSG_PAYLOAD(m)				\
 	(void *)(((struct cifsd_ipc_msg *)(m))->____payload)
 
+#define CIFSD_STATUS_IPC_FATAL_ERROR	11
+
 struct cifsd_ipc_msg *ipc_msg_alloc(size_t sz);
 void ipc_msg_free(struct cifsd_ipc_msg *msg);
 


### PR DESCRIPTION
Do not loop in cifsd waiting for user to kill the manager process,
but terminate it automatically on any IPC error.

$ ./cifsd/cifsd -n
[cifsd-worker/3300]: INFO: share exists ipc$
[cifsd-worker/3300]: ERROR: Recv() error Invalid input data or parameter [-7]
[cifsd-manager/3281]: ERROR: WARNING: child process exited abnormally: 3300
[cifsd-manager/3281]: ERROR: Fatal IPC error. Terminating. Check dmesg.
[cifsd-manager/3281]: ERROR: can't execute kill 3300: No such process
[cifsd-manager/3281]: INFO: Exiting. Bye!

$ dmesg | tail -1
[ 1714.910124] kcifsd: cifsd_ipc_validate_version:49: Daemon and kernel module version mismatch. cifsd: 1, kernel module: 3. User-space cifsd should terminate.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>