### PR TITLE
cifsd-tools: enable tbuf and rbuf caching by default

### DIFF
--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -517,12 +517,16 @@ static void global_group_kv(gpointer _k, gpointer _v, gpointer user_data)
 	if (!cp_key_cmp(_k, "cache trans buffers")) {
 		if (cp_get_group_kv_bool(_v))
 			global_conf.flags |= CIFSD_GLOBAL_FLAG_CACHE_TBUF;
+		else
+			global_conf.flags &= ~CIFSD_GLOBAL_FLAG_CACHE_TBUF;
 		return;
 	}
 
 	if (!cp_key_cmp(_k, "cache read buffers")) {
 		if (cp_get_group_kv_bool(_v))
 			global_conf.flags |= CIFSD_GLOBAL_FLAG_CACHE_RBUF;
+		else
+			global_conf.flags &= ~CIFSD_GLOBAL_FLAG_CACHE_RBUF;
 		return;
 	}
 }
@@ -562,6 +566,12 @@ static void fixup_missing_global_group(void)
 	if (ret)
 		pr_err("Fatal error: Cannot set a global guest account %d\n",
 			ret);
+}
+
+static void default_global_group(void)
+{
+	global_conf.flags |= CIFSD_GLOBAL_FLAG_CACHE_TBUF;
+	global_conf.flags |= CIFSD_GLOBAL_FLAG_CACHE_RBUF;
 }
 
 static void global_group(struct smbconf_group *group)
@@ -609,6 +619,8 @@ out:
 static int __cp_parse_smbconfig(const char *smbconf, GHFunc cb, long flags)
 {
 	int ret;
+
+	default_global_group();
 
 	ret = cp_smbconfig_hash_create(smbconf);
 	if (ret)


### PR DESCRIPTION
Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>