### PR TITLE
cifsd-tools: increase cifsd micro version(v2.0.0 => v2.0.1)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.68])
 
 m4_define([cifsd_tools_major_ver], [2])
 m4_define([cifsd_tools_minor_ver], [0])
-m4_define([cifsd_tools_micro_ver], [0])
+m4_define([cifsd_tools_micro_ver], [1])
 
 m4_define([cifsd_tools_version],
 	[cifsd_tools_major_ver.cifsd_tools_minor_ver.cifsd_tools_micro_ver])


### PR DESCRIPTION
1. merged smb direct bug fix patches into cifsd.
2. merged fix-warning-from-static analyzer patches into cifsd.
3. merged fix-warning-from-static analyzer patches into cifsd-tools.

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>