### PR TITLE
cifsd-tools: remove unneeded libnl for cifsuseradd and cifsshareadd

### DIFF
--- a/cifsshareadd/Makefile.am
+++ b/cifsshareadd/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
-LIBS = $(GLIB_LIBS) $(LIBNL_LIBS)
+LIBS = $(GLIB_LIBS)
 cifsshareadd_LDADD = $(top_builddir)/lib/libcifsdtools.la
 
 sbin_PROGRAMS = cifsshareadd

--- a/cifsuseradd/Makefile.am
+++ b/cifsuseradd/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
-LIBS = $(GLIB_LIBS) $(LIBNL_LIBS)
+LIBS = $(GLIB_LIBS)
 cifsuseradd_LDADD = $(top_builddir)/lib/libcifsdtools.la
 
 sbin_PROGRAMS = cifsuseradd


### PR DESCRIPTION
Signed-off-by: Andy Walsh <andy.walsh44@gmail.com>
Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>