### PR TITLE
ksmbd-tools: fix minlen for KSMBD_EVENT_SHUTTING_DOWN

### DIFF
--- a/mountd/ipc.c
+++ b/mountd/ipc.c
@@ -228,7 +228,7 @@ static struct nla_policy ksmbd_nl_policy[KSMBD_EVENT_MAX] = {
 	},
 
 	[KSMBD_EVENT_SHUTTING_DOWN] = {
-		.minlen = sizeof(struct ksmbd_startup_request),
+		.minlen = sizeof(struct ksmbd_shutdown_request),
 	},
 
 	[KSMBD_EVENT_LOGIN_REQUEST] = {


### PR DESCRIPTION
Signed-off-by: Fredrik Ternerot <fredrikt@axis.com>