### PR TITLE
ksmbd-tools: release user when connection is removed

### DIFF
--- a/lib/management/session.c
+++ b/lib/management/session.c
@@ -218,6 +218,7 @@ int sm_handle_tree_disconnect(unsigned long long sess_id,
 	}
 	g_rw_lock_writer_unlock(&sess->update_lock);
 
+	put_ksmbd_user(sess->user);
 	__put_session(sess);
 	return 0;
 }

--- a/lib/management/tree_conn.c
+++ b/lib/management/tree_conn.c
@@ -202,8 +202,11 @@ bind:
 	resp->status = KSMBD_TREE_CONN_STATUS_OK;
 	resp->connection_flags = conn->flags;
 
-	if (sm_handle_tree_connect(req->session_id, user, conn))
+	if (sm_handle_tree_connect(req->session_id, user, conn)) {
 		pr_err("ERROR: we were unable to bind tree connection\n");
+		tcm_tree_conn_free(conn);
+		put_ksmbd_user(user);
+	}
 	return 0;
 
 out_error:


### PR DESCRIPTION
Release user related to connection when the connection is removed from
session. Previously the user was not released when session was killed or
when a session for the user already existed.

Signed-off-by: Fredrik Ternerot <fredrikt@axis.com>