### PR TITLE
ksmbd-tools: improve configuration reload on SIGHUP

### DIFF
--- a/include/ksmbdtools.h
+++ b/include/ksmbdtools.h
@@ -53,6 +53,8 @@ struct smbconf_global {
 	unsigned int		smb2_max_write;
 	unsigned int		smb2_max_trans;
 	unsigned int		share_fake_fscaps;
+	char			*pwddb;
+	char			*smbconf;
 };
 
 #define KSMBD_LOCK_FILE		"/tmp/ksmbd.lock"

--- a/include/management/share.h
+++ b/include/management/share.h
@@ -55,6 +55,7 @@ struct ksmbd_share {
 	unsigned short	force_gid;
 
 	int		flags;
+	int		state;
 
 	char		*veto_list;
 	int		veto_list_sz;
@@ -143,6 +144,8 @@ struct ksmbd_share *shm_lookup_share(char *name);
 
 struct smbconf_group;
 int shm_add_new_share(struct smbconf_group *group);
+
+void shm_remove_all_shares(void);
 
 void shm_destroy(void);
 int shm_init(void);

--- a/include/management/user.h
+++ b/include/management/user.h
@@ -24,6 +24,7 @@ struct ksmbd_user {
 
 	int		ref_count;
 	int		flags;
+	int		state;
 	GRWLock		update_lock;
 };
 
@@ -46,6 +47,8 @@ int usm_update_user_password(struct ksmbd_user *user, char *pass);
 
 int usm_add_new_user(char *name, char *pwd);
 int usm_add_update_user_from_pwdentry(char *data);
+
+void usm_remove_all_users(void);
 
 void usm_destroy(void);
 int usm_init(void);

--- a/mountd/ipc.c
+++ b/mountd/ipc.c
@@ -21,6 +21,8 @@
 #include <ipc.h>
 #include <worker.h>
 #include <config_parser.h>
+#include <management/user.h>
+#include <management/share.h>
 
 static struct nl_sock *sk;
 
@@ -61,11 +63,38 @@ static int generic_event(int type, void *payload, size_t sz)
 	return 0;
 }
 
+static int parse_reload_configs(const char *pwddb, const char *smbconf)
+{
+	int ret;
+
+	pr_debug("Reload config\n");
+	usm_remove_all_users();
+	ret = cp_parse_pwddb(pwddb);
+	if (ret == -ENOENT) {
+		pr_err("User database file does not exist. %s\n",
+		       "Only guest sessions (if permitted) will work.");
+	} else if (ret) {
+		pr_err("Unable to parse user database\n");
+		return ret;
+	}
+
+	shm_remove_all_shares();
+	ret = cp_parse_reload_smbconf(smbconf);
+	if (ret)
+		pr_err("Unable to parse smb configuration file\n");
+	return ret;
+}
+
 static int handle_generic_event(struct nl_cache_ops *unused,
 				struct genl_cmd *cmd,
 				struct genl_info *info,
 				void *arg)
 {
+	if (ksmbd_health_status & KSMBD_SHOULD_RELOAD_CONFIG) {
+		parse_reload_configs(global_conf.pwddb, global_conf.smbconf);
+		ksmbd_health_status &= ~KSMBD_SHOULD_RELOAD_CONFIG;
+	}
+
 	if (!info->attrs[cmd->c_id])
 		return NL_SKIP;
 


### PR DESCRIPTION
When SIGHUP is received, reload config before next ipc event is handled
instead of after. This makes sure that no more clients could connect
with the old configuration (e.g. an old password) after SIGHUP has been
sent.

When reloading config, remove existing configuration structures before
adding new. Previously, existing shares were not updated and
shares/users that no longer exist in config files were not removed.

Signed-off-by: Fredrik Ternerot <fredrikt@axis.com>