### PR TITLE
ksmbd-tools: release 3.2.5 version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.68])
 
 m4_define([ksmbd_tools_major_ver], [3])
 m4_define([ksmbd_tools_minor_ver], [2])
-m4_define([ksmbd_tools_micro_ver], [4])
+m4_define([ksmbd_tools_micro_ver], [5])
 
 m4_define([ksmbd_tools_version],
 	[ksmbd_tools_major_ver.ksmbd_tools_minor_ver.ksmbd_tools_micro_ver])


### PR DESCRIPTION
Major changes are:
 - remove handling of SIGSEGV signal.
 - add shutdown description.

Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>